### PR TITLE
Ensure creation of files for all declaration types.

### DIFF
--- a/plumbing/ingest-declarations
+++ b/plumbing/ingest-declarations
@@ -9,30 +9,38 @@ $output_dirname = 'mruby-bindings.out/ingested-declarations'
 FileUtils.rm_rf $output_dirname if Dir.exists?($output_dirname)
 FileUtils.mkdir_p $output_dirname
 
-module OutFiles
-  def self.[](filename)
-    @files ||= {}
-    normalized_filename = filename.each_char.reduce('') { |acc, c|
-      c.capitalize == c ? "#{acc}-#{c.downcase}" : "#{acc}#{c}"
-    }.sub(/^-/, '')
-    @files[filename] ||= File.open($output_dirname + '/' + normalized_filename + ".json", 'a')
+class OutFiles
+  def initialize()
+    names = %w{EnumConstantDecl EnumDecl FieldDecl FunctionDecl MacroDefinition ParmDecl StructDecl TypedefDecl}
+    @files = {}
+    names.each { |n|
+      @files[n] = File.new(normalized_path(n), 'w+')
+    }
   end
 
-  def self.close
+  def process_line(line)
+    decl = JSON.parse(line).fetch("kind")
+    @files[decl].puts(line)
+  end
+
+  def close
     @files ||= {}
     @files.each do |k, f|
       f.close
     end
   end
-end
 
-$declaration_files.each do |declaration_filename|
-  open(declaration_filename, 'r') do |declaration_file|
-    while line = declaration_file.gets
-      decl = JSON.parse(line)
-      OutFiles[decl['kind']].puts(line)
-    end
+  private
+  def normalized_path(name)
+    $output_dirname + "/" + name.gsub(/[a-z][A-Z]/) {|s| "#{s[0]}-#{s[1].downcase}" }.downcase + ".json"
   end
 end
 
-OutFiles.close
+out = OutFiles.new
+$declaration_files.each do |declaration_filename|
+  open(declaration_filename, 'r') do |declaration_file|
+    declaration_file.each_line {|line| out.process_line(line) }
+  end
+end
+
+out.close


### PR DESCRIPTION
A file should be created for each declaration type, even if no declarations
of the given type exist in the headers -- future steps expect at least an empty
file to exist for each type.